### PR TITLE
Allow configuring tasks defined as services

### DIFF
--- a/doc/define-tasks.md
+++ b/doc/define-tasks.md
@@ -200,6 +200,25 @@ $schedule->add(new NullTask('daily email'))
 ;
 ```
 
+## Task Services
+
+If you have a [custom task](extending.md#custom-tasks), you can define it as a service
+and add via the [bundle configuration](define-schedule.md#bundle-configuration):
+
+```yaml
+# config/services.yaml
+
+services:
+    my_task: App\Schedule\Task\MyTask
+
+# config/packages/zenstruck_schedule.yaml
+
+zenstruck_schedule:
+    tasks:
+        -   task: '@my_task'
+            frequency: '0 * * * *'
+```
+
 ## Task Description
 
 Optionally add a unique description to your task. If none is provided, tasks define a

--- a/doc/extending.md
+++ b/doc/extending.md
@@ -96,6 +96,23 @@ $schedule->add(new MessageTask(new DoSomething()))
 ;
 ```
 
+If applicable, you can alternatively configure the task as a service and add via
+the [bundle configuration](define-schedule.md#bundle-configuration):
+
+```yaml
+# config/services.yaml
+
+services:
+    message_task: App\Schedule\MessageTask
+
+# config/packages/zenstruck_schedule.yaml
+
+zenstruck_schedule:
+    tasks:
+        -   task: '@message_task'
+            frequency: '30 13 * * *'
+```
+
 ## Custom Extensions
 
 The primary way of hooking into schedule/task events is with extensions. Extensions

--- a/doc/index.md
+++ b/doc/index.md
@@ -33,14 +33,15 @@ Task Scheduling feature](https://laravel.com/docs/master/scheduling).
         3. [ProcessTask](define-tasks.md#processtask)
         4. [CompoundTask](define-tasks.md#compoundtask)
         5. [NullTask](define-tasks.md#nulltask)
-    2. [Task Description](define-tasks.md#task-description)
-    3. [Frequency](define-tasks.md#frequency)
+    2. [Task Services](define-tasks.md#task-services)
+    3. [Task Description](define-tasks.md#task-description)
+    4. [Frequency](define-tasks.md#frequency)
         1. [Cron Expression](define-tasks.md#cron-expression)
         2. [Fluent Expression Builder](define-tasks.md#fluent-expression-builder)
         3. [Hashed Cron Expression](define-tasks.md#hashed-cron-expression)
-    4. [Task ID](define-tasks.md#task-id)
-    5. [Timezone](define-tasks.md#timezone)
-    6. [Task Extensions](define-tasks.md#task-extensions)
+    5. [Task ID](define-tasks.md#task-id)
+    6. [Timezone](define-tasks.md#timezone)
+    7. [Task Extensions](define-tasks.md#task-extensions)
         1. [Filters](define-tasks.md#filters)
         2. [Callbacks](define-tasks.md#callbacks)
         3. [Ping Webhook](define-tasks.md#ping-webhook)
@@ -254,7 +255,7 @@ zenstruck_schedule:
         # Prototype
         -
 
-            # Defaults to CommandTask, prefix with "bash:" to create ProcessTask, pass (null) to create NullTask, pass array of commands to create CompoundTask (optionally keyed by description)
+            # Defaults to CommandTask, prefix with "bash:" to create ProcessTask, prefix with "@" for service, pass (null) to create NullTask, pass array of commands to create CompoundTask (optionally keyed by description)
             task:                 ~ # Required, Example: "my:command arg1 --option1=value" or "bash:/bin/my-script"
 
             # Cron expression

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -126,7 +126,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->children()
                     ->arrayNode('task')
-                        ->info('Defaults to CommandTask, prefix with "bash:" to create ProcessTask, pass (null) to create NullTask, pass array of commands to create CompoundTask (optionally keyed by description)')
+                        ->info('Defaults to CommandTask, prefix with "bash:" to create ProcessTask, prefix with "@" for service, pass (null) to create NullTask, pass array of commands to create CompoundTask (optionally keyed by description)')
                         ->example('"my:command arg1 --option1=value" or "bash:/bin/my-script"')
                         ->validate()
                             ->ifTrue(function ($v) {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -28,8 +28,13 @@
             <tag name="kernel.event_subscriber" />
         </service>
 
+        <service id="zenstruck_schedule.task_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
+            <tag name="container.service_locator" />
+        </service>
+
         <service id="Zenstruck\ScheduleBundle\EventListener\TaskConfigurationSubscriber">
             <argument /> <!-- task config -->
+            <argument type="service" id="zenstruck_schedule.task_locator" />
             <tag name="kernel.event_subscriber" />
         </service>
 


### PR DESCRIPTION
```yaml
# config/services.yaml
services:
    my_task: App\Schedule\Task\MyTask

# config/packages/zenstruck_schedule.yaml
zenstruck_schedule:
    tasks:
        -   command: '@my_task'
            frequency: '0 * * * *'
```