### PR TITLE
[minor] add MockLogger to just check the message (not level)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,6 @@
         "branch-alias": {
             "dev-master": "1.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/tests/Fixture/MockLogger.php
+++ b/tests/Fixture/MockLogger.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Tests\Fixture;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MockLogger extends AbstractLogger
+{
+    private $records = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = $message;
+    }
+
+    public function hasMessageThatContains(string $expected): bool
+    {
+        foreach ($this->records as $record) {
+            if (false !== \mb_strpos($record, $expected)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Schedule/Extension/SingleServerExtensionTest.php
+++ b/tests/Schedule/Extension/SingleServerExtensionTest.php
@@ -3,7 +3,6 @@
 namespace Zenstruck\ScheduleBundle\Tests\Schedule\Extension;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\Test\TestLogger;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\FlockStore;
 use Zenstruck\ScheduleBundle\Schedule;
@@ -13,6 +12,7 @@ use Zenstruck\ScheduleBundle\Schedule\Extension\Handler\SingleServerHandler;
 use Zenstruck\ScheduleBundle\Schedule\Extension\SingleServerExtension;
 use Zenstruck\ScheduleBundle\Schedule\ScheduleRunContext;
 use Zenstruck\ScheduleBundle\Schedule\Task\TaskRunContext;
+use Zenstruck\ScheduleBundle\Tests\Fixture\MockLogger;
 use Zenstruck\ScheduleBundle\Tests\Fixture\MockScheduleBuilder;
 use Zenstruck\ScheduleBundle\Tests\Fixture\MockTask;
 
@@ -26,7 +26,7 @@ final class SingleServerExtensionTest extends TestCase
      */
     public function can_lock_schedule()
     {
-        $logger = new TestLogger();
+        $logger = new MockLogger();
         $lockFactory = new LockFactory(new FlockStore());
         $lockFactory->setLogger($logger);
 
@@ -36,8 +36,8 @@ final class SingleServerExtensionTest extends TestCase
             ->run()
         ;
 
-        $this->assertTrue($logger->hasInfoThatContains('Successfully acquired'));
-        $this->assertTrue($logger->hasInfoThatContains('Expiration defined'));
+        $this->assertTrue($logger->hasMessageThatContains('Successfully acquired'));
+        $this->assertTrue($logger->hasMessageThatContains('Expiration defined'));
     }
 
     /**
@@ -45,7 +45,7 @@ final class SingleServerExtensionTest extends TestCase
      */
     public function can_lock_task()
     {
-        $logger = new TestLogger();
+        $logger = new MockLogger();
         $lockFactory = new LockFactory(new FlockStore());
         $lockFactory->setLogger($logger);
 
@@ -55,8 +55,8 @@ final class SingleServerExtensionTest extends TestCase
             ->run()
         ;
 
-        $this->assertTrue($logger->hasInfoThatContains('Successfully acquired'));
-        $this->assertTrue($logger->hasInfoThatContains('Expiration defined'));
+        $this->assertTrue($logger->hasMessageThatContains('Successfully acquired'));
+        $this->assertTrue($logger->hasMessageThatContains('Expiration defined'));
     }
 
     /**

--- a/tests/Schedule/Extension/WithoutOverlappingExtensionTest.php
+++ b/tests/Schedule/Extension/WithoutOverlappingExtensionTest.php
@@ -3,7 +3,6 @@
 namespace Zenstruck\ScheduleBundle\Tests\Schedule\Extension;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\Test\TestLogger;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\FlockStore;
 use Zenstruck\ScheduleBundle\Schedule;
@@ -11,6 +10,7 @@ use Zenstruck\ScheduleBundle\Schedule\Exception\SkipTask;
 use Zenstruck\ScheduleBundle\Schedule\Extension\Handler\WithoutOverlappingHandler;
 use Zenstruck\ScheduleBundle\Schedule\ScheduleRunContext;
 use Zenstruck\ScheduleBundle\Schedule\Task\TaskRunContext;
+use Zenstruck\ScheduleBundle\Tests\Fixture\MockLogger;
 use Zenstruck\ScheduleBundle\Tests\Fixture\MockScheduleBuilder;
 use Zenstruck\ScheduleBundle\Tests\Fixture\MockTask;
 
@@ -41,7 +41,7 @@ final class WithoutOverlappingExtensionTest extends TestCase
      */
     public function lock_is_released_after_task()
     {
-        $logger = new TestLogger();
+        $logger = new MockLogger();
         $lockFactory = new LockFactory(new FlockStore());
         $lockFactory->setLogger($logger);
 
@@ -51,7 +51,7 @@ final class WithoutOverlappingExtensionTest extends TestCase
             ->run()
         ;
 
-        $this->assertTrue($logger->hasInfoThatContains('Successfully acquired'));
-        $this->assertTrue($logger->hasInfoThatContains('Expiration defined'));
+        $this->assertTrue($logger->hasMessageThatContains('Successfully acquired'));
+        $this->assertTrue($logger->hasMessageThatContains('Expiration defined'));
     }
 }

--- a/tests/Schedule/Task/Runner/PingTaskRunnerTest.php
+++ b/tests/Schedule/Task/Runner/PingTaskRunnerTest.php
@@ -61,7 +61,9 @@ final class PingTaskRunnerTest extends TestCase
         $this->assertTrue($context->isFailure());
         $this->assertCount(1, $run = $context->getFailures());
         $this->assertInstanceOf(ClientException::class, $run[0]->getException());
-        $this->assertSame('ClientException: HTTP/1.1 404 Not Found returned for "https://example.com/".', $run[0]->getDescription());
+        $this->assertStringContainsString('ClientException', $run[0]->getDescription());
+        $this->assertStringContainsString('HTTP/1.1 404 Not Found', $run[0]->getDescription());
+        $this->assertStringContainsString('https://example.com/', $run[0]->getDescription());
     }
 
     /**
@@ -86,7 +88,9 @@ final class PingTaskRunnerTest extends TestCase
         $this->assertTrue($context->isFailure());
         $this->assertCount(1, $run = $context->getFailures());
         $this->assertInstanceOf(ServerException::class, $run[0]->getException());
-        $this->assertSame('ServerException: HTTP/1.1 500 Internal Server Error returned for "https://example.com/".', $run[0]->getDescription());
+        $this->assertStringContainsString('ServerException', $run[0]->getDescription());
+        $this->assertStringContainsString('HTTP/1.1 500 Internal Server Error', $run[0]->getDescription());
+        $this->assertStringContainsString('https://example.com/', $run[0]->getDescription());
     }
 
     private static function createBuilder(MockHttpClient $httpClient): MockScheduleBuilder


### PR DESCRIPTION
Symfony 5.2 changed the log level in the Lock component from info
to debug.