### PR TITLE
Check if kernel definition is null

### DIFF
--- a/src/DependencyInjection/Compiler/ScheduleBuilderKernelPass.php
+++ b/src/DependencyInjection/Compiler/ScheduleBuilderKernelPass.php
@@ -19,6 +19,10 @@ final class ScheduleBuilderKernelPass implements CompilerPassInterface
 
         $kernel = $container->getDefinition('kernel');
 
+        if (null === $kernel->getClass()) {
+            return;
+        }
+
         if ((new \ReflectionClass($kernel->getClass()))->implementsInterface(ScheduleBuilder::class)) {
             $kernel->addTag('schedule.builder');
         }

--- a/tests/DependencyInjection/Compiler/ScheduleBuilderKernelPassTest.php
+++ b/tests/DependencyInjection/Compiler/ScheduleBuilderKernelPassTest.php
@@ -47,6 +47,18 @@ final class ScheduleBuilderKernelPassTest extends AbstractCompilerPassTestCase
         $this->assertSame([], $this->container->getDefinition('kernel')->getTags());
     }
 
+    /**
+     * @test
+     */
+    public function does_not_add_tag_if_kernel_class_is_null()
+    {
+        $this->setDefinition('kernel', new Definition());
+
+        $this->compile();
+
+        $this->assertSame([], $this->container->getDefinition('kernel')->getTags());
+    }
+
     protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ScheduleBuilderKernelPass());


### PR DESCRIPTION
In Symfony 3.x installation, it might generate the error `Class not exit`.

Checking if the getClass() method returns null solves the problem.