### PR TITLE
`CommandTaskRunner`: reset SHELL_VERBOSITY to pre-run state

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,12 @@
 coverage:
   status:
     project:
-        default:
-          target: auto
-          threshold: 0%
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 50%
 
 comment: false

--- a/src/Schedule/Task/Runner/CommandTaskRunner.php
+++ b/src/Schedule/Task/Runner/CommandTaskRunner.php
@@ -27,6 +27,7 @@ final class CommandTaskRunner implements TaskRunner
      */
     public function __invoke(Task $task): Result
     {
+        $shellVerbosityResetter = new ShellVerbosityResetter();
         $output = new BufferedOutput();
         $this->application->setCatchExceptions(false);
         $this->application->setAutoExit(false);
@@ -35,6 +36,8 @@ final class CommandTaskRunner implements TaskRunner
             $exitCode = $this->application->run($task->createCommandInput($this->application), $output);
         } catch (\Throwable $e) {
             return Result::exception($task, $e, $output->fetch());
+        } finally {
+            $shellVerbosityResetter->reset();
         }
 
         if (0 === $exitCode) {

--- a/src/Schedule/Task/Runner/ShellVerbosityResetter.php
+++ b/src/Schedule/Task/Runner/ShellVerbosityResetter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Schedule\Task\Runner;
+
+/**
+ * @internal
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ShellVerbosityResetter
+{
+    private $var;
+    private $env;
+    private $server;
+
+    public function __construct()
+    {
+        $this->var = \getenv('SHELL_VERBOSITY');
+        $this->env = $_ENV['SHELL_VERBOSITY'] ?? false;
+        $this->server = $_SERVER['SHELL_VERBOSITY'] ?? false;
+    }
+
+    public function reset(): void
+    {
+        $this->resetVar();
+        $this->resetEnv();
+        $this->resetServer();
+    }
+
+    private function resetVar(): void
+    {
+        if (!\function_exists('putenv')) {
+            return;
+        }
+
+        if (false === $this->var) {
+            // unset as it wasn't set to begin with
+            @\putenv('SHELL_VERBOSITY');
+
+            return;
+        }
+
+        @\putenv("SHELL_VERBOSITY={$this->var}");
+    }
+
+    private function resetEnv(): void
+    {
+        if (false === $this->env) {
+            // unset as it wasn't set to begin with
+            unset($_ENV['SHELL_VERBOSITY']);
+
+            return;
+        }
+
+        $_ENV['SHELL_VERBOSITY'] = $this->env;
+    }
+
+    private function resetServer(): void
+    {
+        if (false === $this->server) {
+            // unset as it wasn't set to begin with
+            unset($_SERVER['SHELL_VERBOSITY']);
+
+            return;
+        }
+
+        $_SERVER['SHELL_VERBOSITY'] = $this->server;
+    }
+}


### PR DESCRIPTION
`Application::run()` sets the `SHELL_VERBOSITY` environment variable globally. This causes subsequent tasks run in the same process to use this new value. This could lead to unexpected consequences (more log data than expected). This change captures the variable before running the command and resets it to this starting state after.