### PR TITLE
[minor] capture stdout output in failed process task result

### DIFF
--- a/src/Schedule/Task/Runner/ProcessTaskRunner.php
+++ b/src/Schedule/Task/Runner/ProcessTaskRunner.php
@@ -28,7 +28,7 @@ final class ProcessTaskRunner implements TaskRunner
         return Result::failure(
             $task,
             "Exit {$process->getExitCode()}: {$process->getExitCodeText()}",
-            $process->getErrorOutput()
+            $process->getOutput().$process->getErrorOutput()
         );
     }
 

--- a/tests/Fixture/script.sh
+++ b/tests/Fixture/script.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+
+fwrite(STDOUT, "non-error output\n");
+fwrite(STDERR, "error output\n");
+
+exit(1);

--- a/tests/Schedule/Task/Runner/ProcessTaskRunnerTest.php
+++ b/tests/Schedule/Task/Runner/ProcessTaskRunnerTest.php
@@ -34,4 +34,16 @@ final class ProcessTaskRunnerTest extends TestCase
         $this->assertSame('Exit 127: Command not found', $result->getDescription());
         $this->assertSame("sh: 1: sdfsdfsdf: not found\n", $result->getOutput());
     }
+
+    /**
+     * @test
+     */
+    public function failed_result_contains_non_error_output()
+    {
+        $result = (new ProcessTaskRunner())(new ProcessTask(\sprintf('$(which php) %s', __DIR__.'/../../../Fixture/script.sh')));
+
+        $this->assertTrue($result->isFailure());
+        $this->assertSame('Exit 1: General error', $result->getDescription());
+        $this->assertSame("non-error output\nerror output\n", $result->getOutput());
+    }
 }


### PR DESCRIPTION
Previously, only the stderr was captured.