### PR TITLE
[minor][SMALL BC BREAK] schedule:run now has no output for no tasks

### DIFF
--- a/src/EventListener/ScheduleConsoleOutputSubscriber.php
+++ b/src/EventListener/ScheduleConsoleOutputSubscriber.php
@@ -78,20 +78,20 @@ final class ScheduleConsoleOutputSubscriber implements EventSubscriberInterface
         $allTaskCount = \count($context->getSchedule()->all());
         $dueTaskCount = \count($context->dueTasks());
 
-        if (0 === $dueTaskCount) {
-            $this->io->note(\sprintf('No tasks due to run. (%s total tasks)', $allTaskCount));
-
-            return;
+        if ($dueTaskCount > 0) {
+            $this->io->comment(\sprintf(
+                '%sRunning <info>%s</info> %stask%s. (%s total tasks)',
+                $context->isForceRun() ? '<error>Force</error> ' : '',
+                $dueTaskCount,
+                $context->isForceRun() ? '' : 'due ',
+                $dueTaskCount > 1 ? 's' : '',
+                $allTaskCount
+            ));
         }
 
-        $this->io->comment(\sprintf(
-            '%sRunning <info>%s</info> %stask%s. (%s total tasks)',
-            $context->isForceRun() ? '<error>Force</error> ' : '',
-            $dueTaskCount,
-            $context->isForceRun() ? '' : 'due ',
-            $dueTaskCount > 1 ? 's' : '',
-            $allTaskCount
-        ));
+        if ($this->io->isDebug()) {
+            $this->io->note(\sprintf('No tasks due to run. (%s total tasks)', $allTaskCount));
+        }
     }
 
     public function beforeTask(BeforeTaskEvent $event): void

--- a/tests/Command/ScheduleRunCommandTest.php
+++ b/tests/Command/ScheduleRunCommandTest.php
@@ -20,13 +20,28 @@ final class ScheduleRunCommandTest extends TestCase
     /**
      * @test
      */
-    public function no_tasks_defined()
+    public function no_tasks_defined(): void
     {
         $dispatcher = new EventDispatcher();
         $runner = (new MockScheduleBuilder())->getRunner($dispatcher);
         $commandTester = new CommandTester(new ScheduleRunCommand($runner, $dispatcher));
 
         $exit = $commandTester->execute([]);
+
+        $this->assertSame(0, $exit);
+        $this->assertSame('', $commandTester->getDisplay());
+    }
+
+    /**
+     * @test
+     */
+    public function no_tasks_defined_debug()
+    {
+        $dispatcher = new EventDispatcher();
+        $runner = (new MockScheduleBuilder())->getRunner($dispatcher);
+        $commandTester = new CommandTester(new ScheduleRunCommand($runner, $dispatcher));
+
+        $exit = $commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_DEBUG]);
 
         $this->assertSame(0, $exit);
         $this->assertStringContainsString('No tasks due to run. (0 total tasks)', $commandTester->getDisplay());


### PR DESCRIPTION
- passing `-vvv` to `schedule:run` brings back the old behavior
- closes #48