### PR TITLE
Add `AsScheduledTask` attribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         php: [7.4, 8.0, 8.1]
         deps: [hightest]
-        symfony: [4.4.*, 5.3.*, 5.4.*]
+        symfony: [4.4.*, 5.4.*]
         include:
           - php: 7.2
             deps: lowest
@@ -36,7 +36,7 @@ jobs:
   code-coverage:
     uses: zenstruck/.github/.github/workflows/php-coverage-codecov.yml@main
     with:
-      php: 7.4
+      php: 8.1
       phpunit: simple-phpunit
 
   composer-validate:
@@ -45,8 +45,7 @@ jobs:
   cs-check:
     uses: zenstruck/.github/.github/workflows/php-cs-fixer.yml@main
     with:
-      php: 7.2
-      version: 3.4
+      php: 8.0
 
   sca:
     uses: zenstruck/.github/.github/workflows/php-stan.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /build/
 /.php-cs-fixer.cache
 /.phpunit.result.cache
+/var/

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Task Scheduling feature](https://laravel.com/docs/master/scheduling).
     1. [ScheduleBuilder Service](doc/define-schedule.md#schedulebuilder-service)
     2. [Your Kernel](doc/define-schedule.md#your-kernel)
     3. [Bundle Configuration](doc/define-schedule.md#bundle-configuration)
-    4. [Self-Scheduling Commands](doc/define-schedule.md#self-scheduling-commands)
-    5. [Timezone](doc/define-schedule.md#timezone)
-    6. [Schedule Extensions](doc/define-schedule.md#schedule-extensions)
+    4. [`AsScheduledTask` Attribute](doc/define-schedule.md#asscheduledtask-attribute)
+    5. [Self-Scheduling Commands](doc/define-schedule.md#self-scheduling-commands)
+    6. [Timezone](doc/define-schedule.md#timezone)
+    7. [Schedule Extensions](doc/define-schedule.md#schedule-extensions)
         1. [Filters](doc/define-schedule.md#filters)
         2. [Callbacks](doc/define-schedule.md#callbacks)
         3. [Ping Webhook](doc/define-schedule.md#ping-webhook)
@@ -104,7 +105,7 @@ $ composer require zenstruck/schedule-bundle
                 ->sundays()
                 ->at(1)
             ;
-   
+
             // ...
         }
     }
@@ -239,7 +240,7 @@ zenstruck_schedule:
     tasks:
 
         # Example:
-        - 
+        -
             task:                send:sales-report --detailed
             frequency:           '0 * * * *'
             description:         Send sales report hourly

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpstan/phpstan": "^1.4",
         "psr/log": "^1.1",
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
         "symfony/http-client": "^4.3|^5.0|^6.0",
         "symfony/lock": "^4.4|^5.0|^6.0",
         "symfony/mailer": "^4.4|^5.0|^6.0",

--- a/doc/cli-commands.md
+++ b/doc/cli-commands.md
@@ -31,7 +31,7 @@ Consider the following schedule definition:
 zenstruck_schedule:
     schedule_extensions:
         on_single_server: ~
-    
+
     tasks:
         -   task: send-sales-report --hourly
             description: Send the hourly sales report
@@ -54,16 +54,16 @@ $ php bin/console schedule:list
 2 Scheduled Tasks Configured
 ============================
 
- ----------------- ------------------------------ ------------ ------------------------------------------------- --------------------------- 
-  Type              Description                    Extensions   Frequency                                         Next Run                   
- ----------------- ------------------------------ ------------ ------------------------------------------------- --------------------------- 
-  [!] CommandTask   Send the hourly sales report   2            15 * * * 1-5 (Once an hour 5 days a week)         2020-01-22T14:15:00-05:00  
-  CommandTask       Send the weekly sales report   1            0 1 * * 1-5 (Every day 5 days a week at 1:00am)   2020-01-23T01:00:00-05:00  
- ----------------- ------------------------------ ------------ ------------------------------------------------- --------------------------- 
+ ----------------- ------------------------------ ------------ ------------------------------------------------- ---------------------------
+  Type              Description                    Extensions   Frequency                                         Next Run
+ ----------------- ------------------------------ ------------ ------------------------------------------------- ---------------------------
+  [!] CommandTask   Send the hourly sales report   2            15 * * * 1-5 (Once an hour 5 days a week)         2020-01-22T14:15:00-05:00
+  CommandTask       Send the weekly sales report   1            0 1 * * 1-5 (Every day 5 days a week at 1:00am)   2020-01-23T01:00:00-05:00
+ ----------------- ------------------------------ ------------ ------------------------------------------------- ---------------------------
 
  [WARNING] 1 task issue:
 
- [ERROR] To use the email extension you must configure a mailer (config path: "zenstruck_schedule.mailer").      
+ [ERROR] To use the email extension you must configure a mailer (config path: "zenstruck_schedule.mailer").
 
  ! [NOTE] For more details, run php bin/console schedule:list --detail
 
@@ -90,13 +90,13 @@ $ php bin/console schedule:list --detail
 (1/2) CommandTask: Send the hourly sales report
 -----------------------------------------------
 
- ------------------- ---------------------------------------------------- 
-  ID                  9d2023944f540105dd47f7f314138fe92e40300c            
-  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask  
-  Command Arguments   --hourly                                            
-  Frequency           15 * * * 1-5 (Once an hour 5 days a week)           
-  Next Run            Wed, Jan 22, 2020 @ 2:15 (America/New_York -0500)   
- ------------------- ---------------------------------------------------- 
+ ------------------- ----------------------------------------------------
+  ID                  9d2023944f540105dd47f7f314138fe92e40300c
+  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask
+  Command Arguments   --hourly
+  Frequency           15 * * * 1-5 (Once an hour 5 days a week)
+  Next Run            Wed, Jan 22, 2020 @ 2:15 (America/New_York -0500)
+ ------------------- ----------------------------------------------------
 
  // 2 Task Extensions:
 
@@ -105,18 +105,18 @@ $ php bin/console schedule:list --detail
 
  [WARNING] 1 issue with this task:
 
- [ERROR] To use the email extension you must configure a mailer (config path: "zenstruck_schedule.mailer").      
+ [ERROR] To use the email extension you must configure a mailer (config path: "zenstruck_schedule.mailer").
 
 (2/2) CommandTask: Send the weekly sales report
 -----------------------------------------------
 
- ------------------- ---------------------------------------------------- 
-  ID                  92e08f41a257b69fe877e132559fb7396e308309            
-  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask  
-  Command Arguments   --daily                                             
-  Frequency           0 1 * * 1-5 (Every day 5 days a week at 1:00am)     
-  Next Run            Thu, Jan 23, 2020 @ 1:00 (America/New_York -0500)   
- ------------------- ---------------------------------------------------- 
+ ------------------- ----------------------------------------------------
+  ID                  92e08f41a257b69fe877e132559fb7396e308309
+  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask
+  Command Arguments   --daily
+  Frequency           0 1 * * 1-5 (Every day 5 days a week at 1:00am)
+  Next Run            Thu, Jan 23, 2020 @ 1:00 (America/New_York -0500)
+ ------------------- ----------------------------------------------------
 
  // 1 Task Extension:
 
@@ -152,12 +152,12 @@ $ php bin/console schedule:list
 2 Scheduled Tasks Configured
 ============================
 
- ------------- ------------------------------ ------------ ------------------------------------------------- --------------------------- 
-  Type          Description                    Extensions   Frequency                                         Next Run                   
- ------------- ------------------------------ ------------ ------------------------------------------------- --------------------------- 
-  CommandTask   Send the hourly sales report   2            15 * * * 1-5 (Once an hour 5 days a week)         2020-01-22T14:15:00-05:00  
-  CommandTask   Send the weekly sales report   1            0 1 * * 1-5 (Every day 5 days a week at 1:00am)   2020-01-23T01:00:00-05:00  
- ------------- ------------------------------ ------------ ------------------------------------------------- --------------------------- 
+ ------------- ------------------------------ ------------ ------------------------------------------------- ---------------------------
+  Type          Description                    Extensions   Frequency                                         Next Run
+ ------------- ------------------------------ ------------ ------------------------------------------------- ---------------------------
+  CommandTask   Send the hourly sales report   2            15 * * * 1-5 (Once an hour 5 days a week)         2020-01-22T14:15:00-05:00
+  CommandTask   Send the weekly sales report   1            0 1 * * 1-5 (Every day 5 days a week at 1:00am)   2020-01-23T01:00:00-05:00
+ ------------- ------------------------------ ------------ ------------------------------------------------- ---------------------------
 
  ! [NOTE] For more details, run php bin/console schedule:list --detail
 
@@ -181,13 +181,13 @@ $ php bin/console schedule:list --detail
 (1/2) CommandTask: Send the hourly sales report
 -----------------------------------------------
 
- ------------------- ---------------------------------------------------- 
-  ID                  9d2023944f540105dd47f7f314138fe92e40300c            
-  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask  
-  Command Arguments   --hourly                                            
-  Frequency           15 * * * 1-5 (Once an hour 5 days a week)           
-  Next Run            Wed, Jan 22, 2020 @ 2:15 (America/New_York -0500)   
- ------------------- ---------------------------------------------------- 
+ ------------------- ----------------------------------------------------
+  ID                  9d2023944f540105dd47f7f314138fe92e40300c
+  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask
+  Command Arguments   --hourly
+  Frequency           15 * * * 1-5 (Once an hour 5 days a week)
+  Next Run            Wed, Jan 22, 2020 @ 2:15 (America/New_York -0500)
+ ------------------- ----------------------------------------------------
 
  // 2 Task Extensions:
 
@@ -197,13 +197,13 @@ $ php bin/console schedule:list --detail
 (2/2) CommandTask: Send the weekly sales report
 -----------------------------------------------
 
- ------------------- ---------------------------------------------------- 
-  ID                  92e08f41a257b69fe877e132559fb7396e308309            
-  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask  
-  Command Arguments   --daily                                             
-  Frequency           0 1 * * 1-5 (Every day 5 days a week at 1:00am)     
-  Next Run            Thu, Jan 23, 2020 @ 1:00 (America/New_York -0500)   
- ------------------- ---------------------------------------------------- 
+ ------------------- ----------------------------------------------------
+  ID                  92e08f41a257b69fe877e132559fb7396e308309
+  Class               Zenstruck\ScheduleBundle\Schedule\Task\CommandTask
+  Command Arguments   --daily
+  Frequency           0 1 * * 1-5 (Every day 5 days a week at 1:00am)
+  Next Run            Thu, Jan 23, 2020 @ 1:00 (America/New_York -0500)
+ ------------------- ----------------------------------------------------
 
  // 1 Task Extension:
 

--- a/doc/define-schedule.md
+++ b/doc/define-schedule.md
@@ -74,7 +74,7 @@ and [schedule extensions](#schedule-extensions) can be configured:
 zenstruck_schedule:
     timezone: UTC
     ping_on_success: https://example.com/schedule-success
-    
+
     tasks:
         -   task: app:send-weekly-report --detailed
             frequency: '0 1 * * 0' # sundays @ 1am
@@ -85,10 +85,68 @@ zenstruck_schedule:
             unless_between: 11-13 # except at lunch
 ```
 
+## `AsScheduledTask` Attribute
+
+_**NOTE:** PHP 8+ and Symfony 5.4+ required to use this feature._
+
+You can mark [invokable services](#invokable-asscheduledtask-services) and
+[console commands](#asscheduledtask-console-commands) with the
+`Zenstruck\ScheduleBundle\Attribute\AsScheduledTask` attribute to _self-schedule_ them.
+
+### Invokable `AsScheduledTask` Services
+
+Services can be marked with `AsScheduledTask` to be scheduled (as a
+[`CallbackTask`](define-tasks.md#callbacktask)). These services must be _callable_
+(implement `__invoke()`) or have a custom method configured. The method must be
+public and have no required parameters.
+
+```php
+use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;
+
+#[AsScheduledTask('#daily')]
+#[AsScheduledTask('#weekly')] // can be scheduled multiple times
+#[AsScheduledTask('#monthly', description: 'some description')] // optionally set a description
+#[AsScheduledTask('#daily', method: 'someOtherMethod')] // use a different method
+class MyService
+{
+    public function __invoke(): void
+    {
+    }
+
+    public function someOtherMethod(): void
+    {
+    }
+}
+```
+
+### `AsScheduledTask` Console Commands
+
+Console commands can be marked with `AsScheduledTask` to _self-schedule_ them.
+
+**NOTE:** Use [Self-Scheduling Commands](#self-scheduling-commands) if you require more
+fine-grained options.
+
+```php
+use Symfony\Component\Console\Command;
+use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;
+
+#[AsScheduledTask('#daily')]
+#[AsScheduledTask('#weekly')] // can be scheduled multiple times
+#[AsScheduledTask('#monthly', description: 'some description')] // optionally set a description
+#[AsScheduledTask('#daily', arguments: '--no-interaction --verbose')] // optionally set arguments
+class MyCommand extends Command
+{
+    // ...
+}
+```
+
 ## Self-Scheduling Commands
 
 You can make your application's console commands schedule themselves. Have your command
 implement [`SelfSchedulingCommand`](../src/Schedule/SelfSchedulingCommand.php):
+
+**NOTE:** If using PHP 8+ and Symfony 5.4+, see [`AsScheduledTask` Console Commands](#asscheduledtask-console-commands)
+as a possible alternative.
 
 ```php
 // src/Command/WeeklyReportCommand.php

--- a/doc/define-tasks.md
+++ b/doc/define-tasks.md
@@ -45,7 +45,7 @@ task *output*.
 
 $schedule->addCallback(function () {
     // do something
-    
+
     return 'task output';
 });
 ```
@@ -110,7 +110,7 @@ zenstruck_schedule:
 
     ```yaml
     # config/packages/zenstruck_schedule.yaml
-    
+
     zenstruck_schedule:
         tasks:
             -   task: 'bash:cd %kernel.project_dir% && bin/my-script'
@@ -148,10 +148,10 @@ $schedule->addMessage(new MyMessage('argument'), [new DelayStamp(10)]);
 
     ```yaml
     # config/packages/zenstruck_schedule.yaml
-    
+
     zenstruck_schedule:
         messenger: ~
-   
+
         # optionally configure the message bus (uses "message_bus" by default)
         messenger:
             message_bus: my_bus
@@ -698,7 +698,7 @@ zenstruck_schedule:
             default_from: webmaster@example.com # exclude only if a "global from" is defined for your application
             subject_prefix: "[Acme Inc]" # optional
     ```
-   
+
 3. Failed task emails have the subject `[Scheduled Task Failed] CommandTask: failed
    task description` (the subject can be configured). The email body has the following
    structure:
@@ -728,7 +728,7 @@ zenstruck_schedule:
 
     ## Task Output:
 
-    Task's output (if any) 
+    Task's output (if any)
     ```
 
 ### Prevent Overlap
@@ -763,7 +763,7 @@ zenstruck_schedule:
     ```console
     $ composer require symfony/lock
     ```
-   
+
 2. *Optionally* customize the `LockFactory` service in your configuration:
 
     ```yaml

--- a/doc/extending.md
+++ b/doc/extending.md
@@ -115,7 +115,7 @@ Below are some examples of custom extensions:
 ### Example: Skip Schedule if in maintenance mode
 
 Say your application has the concept of maintenance mode. You want to prevent the
-schedule from running in maintenance mode. 
+schedule from running in maintenance mode.
 
 This example assumes your `Kernel` has an `isInMaintenanceMode()` method.
 

--- a/doc/run-schedule.md
+++ b/doc/run-schedule.md
@@ -128,7 +128,7 @@ The following is an example log file (some context excluded):
 [2020-01-20 13:17:13] schedule.INFO: Successfully ran "CommandTask": my:command
 [2020-01-20 13:17:13] schedule.INFO: Running "ProcessTask": fdere -dsdfsd
 [2020-01-20 13:17:13] schedule.ERROR: Failure when running "ProcessTask": fdere -dsdfsd
-[2020-01-20 13:17:13] schedule.INFO: Running "CallbackTask": some callback 
+[2020-01-20 13:17:13] schedule.INFO: Running "CallbackTask": some callback
 [2020-01-20 13:17:13] schedule.CRITICAL: Exception thrown when running "CallbackTask": some callback
 [2020-01-20 13:24:11] schedule.INFO: Running "CommandTask": another:command
 [2020-01-20 13:24:11] schedule.INFO: Skipped "CommandTask": another:command {"reason":"the reason for skip..."}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,8 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <server name="KERNEL_CLASS" value="Zenstruck\ScheduleBundle\Tests\Fixture\Kernel" />
+        <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 
     <testsuites>

--- a/src/Attribute/AsScheduledTask.php
+++ b/src/Attribute/AsScheduledTask.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Attribute;
+
+/**
+ * Schedule an invokable service or console command.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class AsScheduledTask
+{
+    public function __construct(
+        /**
+         * Cron expression or alias.
+         */
+        public string $frequency,
+
+        /**
+         * Task description.
+         */
+        public ?string $description = null,
+
+        /**
+         * The invokable service method to be called when run (must
+         * have no required parameters).
+         *
+         * Only applicable to "invokable services".
+         */
+        public string $method = '__invoke',
+
+        /**
+         * The command arguments (ie "-v --no-interaction").
+         *
+         * Only applicable to "console commands".
+         */
+        public ?string $arguments = null,
+    ) {
+    }
+}

--- a/src/DependencyInjection/Compiler/ScheduledServiceBuilderPass.php
+++ b/src/DependencyInjection/Compiler/ScheduledServiceBuilderPass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Zenstruck\ScheduleBundle\Schedule\Builder\ScheduledServiceBuilder;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class ScheduledServiceBuilderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $builder = $container->getDefinition('zenstruck_schedule.service_builder');
+
+        foreach ($container->findTaggedServiceIds('schedule.service') as $id => $tags) {
+            foreach ($tags as $attributes) {
+                ScheduledServiceBuilder::validate($container->getDefinition($id)->getClass(), $attributes);
+
+                $builder->addMethodCall('add', [new Reference($id), $attributes]);
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/ZenstruckScheduleExtension.php
+++ b/src/DependencyInjection/ZenstruckScheduleExtension.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Process\Process;
+use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;
 use Zenstruck\ScheduleBundle\EventListener\ScheduleTimezoneSubscriber;
 use Zenstruck\ScheduleBundle\EventListener\TaskConfigurationSubscriber;
 use Zenstruck\ScheduleBundle\Schedule\Extension\EmailExtension;
@@ -131,6 +132,15 @@ final class ZenstruckScheduleExtension extends ConfigurableExtension
         }
 
         $this->registerScheduleExtensions($mergedConfig, $container);
+
+        if (\method_exists($container, 'registerAttributeForAutoconfiguration')) {
+            $container->registerAttributeForAutoconfiguration(
+                AsScheduledTask::class,
+                static function(Definition $definition, AsScheduledTask $attribute) {
+                    $definition->addTag('schedule.service', \get_object_vars($attribute));
+                }
+            );
+        }
     }
 
     private function registerScheduleExtensions(array $config, ContainerBuilder $container): void

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -70,5 +70,9 @@
             <argument>%kernel.environment%</argument>
             <tag name="schedule.extension_handler" />
         </service>
+
+        <service id="zenstruck_schedule.service_builder" class="Zenstruck\ScheduleBundle\Schedule\Builder\ScheduledServiceBuilder">
+            <tag name="schedule.builder" />
+        </service>
     </services>
 </container>

--- a/src/Schedule/Builder/ScheduledServiceBuilder.php
+++ b/src/Schedule/Builder/ScheduledServiceBuilder.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Schedule\Builder;
+
+use Symfony\Component\Console\Command\Command;
+use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;
+use Zenstruck\ScheduleBundle\Schedule;
+use Zenstruck\ScheduleBundle\Schedule\ScheduleBuilder;
+use Zenstruck\ScheduleBundle\Schedule\Task;
+use Zenstruck\ScheduleBundle\Schedule\Task\CallbackTask;
+use Zenstruck\ScheduleBundle\Schedule\Task\CommandTask;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class ScheduledServiceBuilder implements ScheduleBuilder
+{
+    /** @var array<int,array{object,array<string,string>}> */
+    private $services = [];
+
+    /**
+     * @param array<string,string> $attributes
+     */
+    public function add(object $service, array $attributes): void
+    {
+        $this->services[] = [$service, $attributes];
+    }
+
+    public function buildSchedule(Schedule $schedule): void
+    {
+        foreach ($this->services as [$service, $attributes]) {
+            $task = $this->createTask($service, $attributes)
+                ->cron($attributes['frequency'])
+            ;
+
+            if ($description = $attributes['description'] ?? null) {
+                $task->description($description);
+            }
+
+            $schedule->add($task);
+        }
+    }
+
+    /**
+     * @param array<string,string> $attributes
+     */
+    public static function validate(?string $class, array $attributes): void
+    {
+        if (!\class_exists($class = (string) $class)) {
+            throw new \LogicException('Class does not exist.');
+        }
+
+        if (!isset($attributes['frequency'])) {
+            throw new \LogicException('Missing frequency tag attribute.');
+        }
+
+        if (\is_a($class, Command::class, true)) {
+            return;
+        }
+
+        if (!isset($attributes['method'])) {
+            throw new \LogicException('Missing method tag attribute.');
+        }
+
+        if ($attributes['arguments'] ?? null) {
+            throw new \LogicException(\sprintf('%s::$arguments used on %s is not usable for non-%s services.', AsScheduledTask::class, $class, Command::class));
+        }
+
+        try {
+            $method = new \ReflectionMethod($class, $attributes['method']);
+        } catch (\ReflectionException $e) {
+            throw new \LogicException(\sprintf('%s::%s() method is required to use with the %s attribute.', $class, $attributes['method'], AsScheduledTask::class));
+        }
+
+        if ($method->isStatic() || !$method->isPublic()) {
+            throw new \LogicException(\sprintf('Method %s::%s() must non-static and public to use with the %s attribute.', $class, $attributes['method'], AsScheduledTask::class));
+        }
+
+        if ($method->getNumberOfRequiredParameters()) {
+            throw new \LogicException(\sprintf('Method %s::%s() must not have any required parameters to use with the %s attribute.', $class, $attributes['method'], AsScheduledTask::class));
+        }
+    }
+
+    /**
+     * @param array<string,string> $attributes
+     */
+    private function createTask(object $service, array $attributes): Task
+    {
+        if ($service instanceof Command) {
+            return new CommandTask((string) $service->getName(), (string) ($attributes['arguments'] ?? null));
+        }
+
+        $callback = [$service, $attributes['method']];
+
+        \assert(\is_callable($callback));
+
+        return new CallbackTask($callback);
+    }
+}

--- a/src/Schedule/Extension/CallbackExtension.php
+++ b/src/Schedule/Extension/CallbackExtension.php
@@ -89,12 +89,20 @@ final class CallbackExtension
 
     public static function createDescriptionFromCallback(callable $callback): string
     {
+        if (\is_array($callback)) {
+            return \sprintf('%s::%s()', \is_object($callback[0]) ? \get_class($callback[0]) : $callback[0], $callback[1]);
+        }
+
+        if (\is_object($callback) && !$callback instanceof \Closure && \method_exists($callback, '__invoke')) {
+            return \sprintf('%s::__invoke()', \get_class($callback));
+        }
+
         $ref = new \ReflectionFunction(\Closure::fromCallable($callback));
 
         if ($class = $ref->getClosureScopeClass()) {
             return "{$class->getName()}:{$ref->getStartLine()}";
         }
 
-        return $ref->getName();
+        return $ref->getName().'()';
     }
 }

--- a/src/Schedule/Task/Runner/MessageTaskRunner.php
+++ b/src/Schedule/Task/Runner/MessageTaskRunner.php
@@ -75,9 +75,9 @@ final class MessageTaskRunner implements TaskRunner
                 return '(none)';
 
             case \is_scalar($result):
-                return \sprintf('(%s) "%s"', get_debug_type($result), $result);
+                return \sprintf('(%s) "%s"', \get_debug_type($result), $result);
         }
 
-        return \sprintf('(%s)', get_debug_type($result));
+        return \sprintf('(%s)', \get_debug_type($result));
     }
 }

--- a/src/ZenstruckScheduleBundle.php
+++ b/src/ZenstruckScheduleBundle.php
@@ -5,6 +5,7 @@ namespace Zenstruck\ScheduleBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Zenstruck\ScheduleBundle\DependencyInjection\Compiler\ScheduleBuilderKernelPass;
+use Zenstruck\ScheduleBundle\DependencyInjection\Compiler\ScheduledServiceBuilderPass;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -16,5 +17,6 @@ final class ZenstruckScheduleBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new ScheduleBuilderKernelPass());
+        $container->addCompilerPass(new ScheduledServiceBuilderPass());
     }
 }

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Tests\Fixture;
+
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Zenstruck\ScheduleBundle\ZenstruckScheduleBundle;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        yield new FrameworkBundle();
+        yield new ZenstruckScheduleBundle();
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    {
+        $c->loadFromExtension('framework', [
+            'secret' => 'S3CRET',
+            'router' => ['utf8' => true],
+            'test' => true,
+        ]);
+        $c->register('logger', NullLogger::class); // disable logging
+        $c->register(ScheduledService::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(ScheduledCommand::class)->setAutowired(true)->setAutoconfigured(true);
+    }
+}

--- a/tests/Fixture/ScheduledCommand.php
+++ b/tests/Fixture/ScheduledCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Tests\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsScheduledTask('@daily')]
+#[AsScheduledTask('@weekly', description: 'run my command')]
+#[AsScheduledTask('@monthly', arguments: '-vv --no-interaction')]
+final class ScheduledCommand extends Command
+{
+    protected static $defaultName = 'my:command';
+}

--- a/tests/Fixture/ScheduledService.php
+++ b/tests/Fixture/ScheduledService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Tests\Fixture;
+
+use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[AsScheduledTask('@daily')]
+#[AsScheduledTask('@weekly', description: 'custom description')]
+#[AsScheduledTask('@monthly', method: 'someMethod')]
+final class ScheduledService
+{
+    public function __invoke(): void
+    {
+    }
+
+    public function someMethod(): void
+    {
+    }
+}

--- a/tests/Integration/ScheduledServiceTest.php
+++ b/tests/Integration/ScheduledServiceTest.php
@@ -33,7 +33,7 @@ final class ScheduledServiceTest extends KernelTestCase
         $this->assertCount(6, $tasks);
 
         $this->assertInstanceOf(CallbackTask::class, $tasks[0]);
-        $this->assertSame(\sprintf('(callable) %s:15', ScheduledService::class), $tasks[0]->getDescription());
+        $this->assertSame(\sprintf('(callable) %s::__invoke()', ScheduledService::class), $tasks[0]->getDescription());
         $this->assertSame('@daily', (string) $tasks[0]->getExpression());
 
         $this->assertInstanceOf(CallbackTask::class, $tasks[1]);
@@ -41,7 +41,7 @@ final class ScheduledServiceTest extends KernelTestCase
         $this->assertSame('@weekly', (string) $tasks[1]->getExpression());
 
         $this->assertInstanceOf(CallbackTask::class, $tasks[2]);
-        $this->assertSame(\sprintf('(callable) %s:19', ScheduledService::class), $tasks[2]->getDescription());
+        $this->assertSame(\sprintf('(callable) %s::someMethod()', ScheduledService::class), $tasks[2]->getDescription());
         $this->assertSame('@monthly', (string) $tasks[2]->getExpression());
 
         $this->assertInstanceOf(CommandTask::class, $tasks[3]);

--- a/tests/Integration/ScheduledServiceTest.php
+++ b/tests/Integration/ScheduledServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\Kernel;
+use Zenstruck\ScheduleBundle\Schedule\ScheduleRunner;
+use Zenstruck\ScheduleBundle\Schedule\Task\CallbackTask;
+use Zenstruck\ScheduleBundle\Schedule\Task\CommandTask;
+use Zenstruck\ScheduleBundle\Tests\Fixture\ScheduledService;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @requires PHP 8
+ */
+final class ScheduledServiceTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        if (Kernel::VERSION_ID < 50400) {
+            $this->markTestSkipped('Not available before Symfony 5.4.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function registers_scheduled_services(): void
+    {
+        $tasks = self::getContainer()->get(ScheduleRunner::class)->buildSchedule()->all();
+
+        $this->assertCount(6, $tasks);
+
+        $this->assertInstanceOf(CallbackTask::class, $tasks[0]);
+        $this->assertSame(\sprintf('(callable) %s:15', ScheduledService::class), $tasks[0]->getDescription());
+        $this->assertSame('@daily', (string) $tasks[0]->getExpression());
+
+        $this->assertInstanceOf(CallbackTask::class, $tasks[1]);
+        $this->assertSame('custom description', $tasks[1]->getDescription());
+        $this->assertSame('@weekly', (string) $tasks[1]->getExpression());
+
+        $this->assertInstanceOf(CallbackTask::class, $tasks[2]);
+        $this->assertSame(\sprintf('(callable) %s:19', ScheduledService::class), $tasks[2]->getDescription());
+        $this->assertSame('@monthly', (string) $tasks[2]->getExpression());
+
+        $this->assertInstanceOf(CommandTask::class, $tasks[3]);
+        $this->assertSame('my:command', $tasks[3]->getDescription());
+        $this->assertSame('@daily', (string) $tasks[3]->getExpression());
+        $this->assertSame('', $tasks[3]->getArguments());
+
+        $this->assertInstanceOf(CommandTask::class, $tasks[4]);
+        $this->assertSame('run my command', $tasks[4]->getDescription());
+        $this->assertSame('@weekly', (string) $tasks[4]->getExpression());
+        $this->assertSame('', $tasks[4]->getArguments());
+
+        $this->assertInstanceOf(CommandTask::class, $tasks[5]);
+        $this->assertSame('my:command', $tasks[5]->getDescription());
+        $this->assertSame('@monthly', (string) $tasks[5]->getExpression());
+        $this->assertSame('-vv --no-interaction', $tasks[5]->getArguments());
+    }
+}

--- a/tests/Schedule/Builder/ScheduledServiceBuilderTest.php
+++ b/tests/Schedule/Builder/ScheduledServiceBuilderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Zenstruck\ScheduleBundle\Tests\Schedule\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\ScheduleBundle\Schedule\Builder\ScheduledServiceBuilder;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ScheduledServiceBuilderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function validate_invalid_class(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate('invalid', []);
+    }
+
+    /**
+     * @test
+     */
+    public function validate_missing_frequency(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate(DummyClass::class, []);
+    }
+
+    /**
+     * @test
+     */
+    public function validate_missing_method(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate(DummyClass::class, ['frequency' => '@daily']);
+    }
+
+    /**
+     * @test
+     */
+    public function validate_invalid_method(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate(DummyClass::class, ['frequency' => '@daily', 'method' => 'invalid']);
+    }
+
+    /**
+     * @test
+     */
+    public function validate_static_method(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate(DummyClass::class, ['frequency' => '@daily', 'method' => 'method1']);
+    }
+
+    /**
+     * @test
+     */
+    public function validate_non_public_method(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate(DummyClass::class, ['frequency' => '@daily', 'method' => 'method3']);
+    }
+
+    /**
+     * @test
+     */
+    public function validate_method_required_parameters(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate(DummyClass::class, ['frequency' => '@daily', 'method' => 'method2']);
+    }
+
+    /**
+     * @test
+     */
+    public function validate_arguments(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        ScheduledServiceBuilder::validate(DummyClass::class, ['frequency' => '@daily', 'method' => '__invoke', 'arguments' => '-v']);
+    }
+}
+
+class DummyClass
+{
+    public function __invoke()
+    {
+    }
+
+    public static function method1()
+    {
+    }
+
+    public function method2($required)
+    {
+    }
+
+    private function method3()
+    {
+    }
+}

--- a/tests/Schedule/Task/CallbackTaskTest.php
+++ b/tests/Schedule/Task/CallbackTaskTest.php
@@ -16,10 +16,10 @@ final class CallbackTaskTest extends TestCase
     public function has_default_description()
     {
         $this->assertMatchesRegularExpression('#^\(callable\) Zenstruck\\\\ScheduleBundle\\\\Tests\\\\Schedule\\\\Task\\\\CallbackTaskTest\:\d+$#', (new CallbackTask(function() {}))->getDescription());
-        $this->assertMatchesRegularExpression('#^\(callable\) Zenstruck\\\\ScheduleBundle\\\\Tests\\\\Schedule\\\\Task\\\\CallbackTaskTest\:\d+$#', (new CallbackTask([$this, __METHOD__]))->getDescription());
-        $this->assertMatchesRegularExpression('#^\(callable\) Zenstruck\\\\ScheduleBundle\\\\Tests\\\\Schedule\\\\Task\\\\FixtureForCallbackTaskTest\:\d+$#', (new CallbackTask(new FixtureForCallbackTaskTest()))->getDescription());
-        $this->assertMatchesRegularExpression('#^\(callable\) Zenstruck\\\\ScheduleBundle\\\\Tests\\\\Schedule\\\\Task\\\\FixtureForCallbackTaskTest\:\d+$#', (new CallbackTask([FixtureForCallbackTaskTest::class, 'staticMethod']))->getDescription());
-        $this->assertSame('(callable) '.__NAMESPACE__.'\callback_task_test_function', (new CallbackTask(__NAMESPACE__.'\callback_task_test_function'))->getDescription());
+        $this->assertSame(\sprintf('(callable) %s()', __METHOD__), (new CallbackTask([$this, __FUNCTION__]))->getDescription());
+        $this->assertSame(\sprintf('(callable) %s::__invoke()', FixtureForCallbackTaskTest::class), (new CallbackTask(new FixtureForCallbackTaskTest()))->getDescription());
+        $this->assertSame(\sprintf('(callable) %s::staticMethod()', FixtureForCallbackTaskTest::class), (new CallbackTask([FixtureForCallbackTaskTest::class, 'staticMethod']))->getDescription());
+        $this->assertSame('(callable) '.__NAMESPACE__.'\callback_task_test_function()', (new CallbackTask(__NAMESPACE__.'\callback_task_test_function'))->getDescription());
     }
 
     /**


### PR DESCRIPTION
Closes #58.

**Usage**

Self-scheduling invokable services:

```php
use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;

#[AsScheduledTask('#daily')]
#[AsScheduledTask('#weekly')] // can be scheduled multiple times
#[AsScheduledTask('#monthly', description: 'some description')] // optionally set a description
#[AsScheduledTask('#daily', method: 'someOtherMethod')] // use a different method
class MyService
{
    public function __invoke(): void
    {
    }

    public function someOtherMethod(): void
    {
    }
}
```

Self-scheduling console commands (alternative):

```php
use Symfony\Component\Console\Command;
use Zenstruck\ScheduleBundle\Attribute\AsScheduledTask;

#[AsScheduledTask('#daily')]
#[AsScheduledTask('#weekly')] // can be scheduled multiple times
#[AsScheduledTask('#monthly', description: 'some description')] // optionally set a description
#[AsScheduledTask('#daily', arguments: '--no-interaction --verbose')] // optionally set arguments
class MyCommand extends Command
{
    // ...
}
```

**Todo**
- [x] Docs
- [x] Console command support