### PR TITLE
RunContext->duration becomes negative at 02:xx on CEST to CET turning…

### DIFF
--- a/src/Schedule/RunContext.php
+++ b/src/Schedule/RunContext.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Helper\Helper;
  */
 abstract class RunContext
 {
-    /** @var \DateTimeImmutable */
+    /** @var int */
     private $startTime;
 
     /** @var int|null */
@@ -20,14 +20,14 @@ abstract class RunContext
 
     public function __construct()
     {
-        $this->startTime = new \DateTimeImmutable('now');
+        $this->startTime = \time();
     }
 
     abstract public function __toString(): string;
 
     final public function getStartTime(): \DateTimeImmutable
     {
-        return $this->startTime;
+        return new \DateTimeImmutable('@'.$this->startTime);
     }
 
     final public function hasRun(): bool
@@ -61,7 +61,7 @@ abstract class RunContext
 
     final protected function markAsRun(int $memory): void
     {
-        $this->duration = \time() - $this->getStartTime()->getTimestamp();
+        $this->duration = \time() - $this->startTime;
         $this->memory = $memory;
     }
 


### PR DESCRIPTION
… day (for example on 30.10.2022 02:05 CEST Europe/Berlin)

Exception backtrace:
```
{
    "class": "TypeError",
    "message": "Return value of Zenstruck\\ScheduleBundle\\Schedule\\RunContext::getFormattedDuration() must be of the type string, null returned",
    "code": 0,
    "file": "/XYZ/vendor/zenstruck/schedule-bundle/src/Schedule/RunContext.php:47",
    "trace": [
        "/XYZ/vendor/zenstruck/schedule-bundle/src/EventListener/ScheduleLoggerSubscriber.php:120",
        "/XYZ/vendor/symfony/event-dispatcher/EventDispatcher.php:270",
        "/XYZ/vendor/symfony/event-dispatcher/EventDispatcher.php:230",
        "/XYZ/vendor/symfony/event-dispatcher/EventDispatcher.php:59",
        "/XYZ/vendor/zenstruck/schedule-bundle/src/Schedule/ScheduleRunner.php:73",
        "/XYZ/vendor/zenstruck/schedule-bundle/src/Command/ScheduleRunCommand.php:70",
        "/XYZ/vendor/symfony/console/Command/Command.php:298",
        "/XYZ/vendor/symfony/console/Application.php:1046",
        "/XYZ/vendor/symfony/framework-bundle/Console/Application.php:96",
        "/XYZ/vendor/symfony/console/Application.php:299",
        "/XYZ/vendor/symfony/framework-bundle/Console/Application.php:82",
        "/XYZ/vendor/symfony/console/Application.php:171",
        "/XYZ/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:54",
        "/XYZ/vendor/autoload_runtime.php:35",
        "/XYZ/bin/console:11"
    ]
}
```