### PR TITLE
Timezone fix

### DIFF
--- a/src/Schedule/RunContext.php
+++ b/src/Schedule/RunContext.php
@@ -18,25 +18,20 @@ use Symfony\Component\Console\Helper\Helper;
  */
 abstract class RunContext
 {
-    /** @var int */
-    private $startTime;
-
-    /** @var int|null */
-    private $duration;
-
-    /** @var int|null */
-    private $memory;
+    private \DateTimeImmutable $startTime;
+    private ?int $duration = null;
+    private ?int $memory = null;
 
     public function __construct()
     {
-        $this->startTime = \time();
+        $this->startTime = new \DateTimeImmutable('now');
     }
 
     abstract public function __toString(): string;
 
     final public function getStartTime(): \DateTimeImmutable
     {
-        return new \DateTimeImmutable('@'.$this->startTime);
+        return $this->startTime;
     }
 
     final public function hasRun(): bool
@@ -70,7 +65,7 @@ abstract class RunContext
 
     final protected function markAsRun(int $memory): void
     {
-        $this->duration = \time() - $this->startTime;
+        $this->duration = \time() - $this->startTime->getTimestamp();
         $this->memory = $memory;
     }
 

--- a/src/Schedule/Task.php
+++ b/src/Schedule/Task.php
@@ -38,18 +38,11 @@ abstract class Task
 
     private const DEFAULT_EXPRESSION = '* * * * *';
 
-    /** @var string */
-    private $description;
+    private string $expression = self::DEFAULT_EXPRESSION;
+    private ?\DateTimeZone $timezone = null;
 
-    /** @var string */
-    private $expression = self::DEFAULT_EXPRESSION;
-
-    /** @var \DateTimeZone|null */
-    private $timezone;
-
-    public function __construct(string $description)
+    public function __construct(private string $description)
     {
-        $this->description = $description;
     }
 
     final public function __toString(): string
@@ -749,8 +742,8 @@ abstract class Task
         return $this->cron(\implode(' ', $segments));
     }
 
-    private function getTimezoneValue(): ?string
+    private function getTimezoneValue(): string
     {
-        return $this->getTimezone() ? $this->getTimezone()->getName() : null;
+        return ($this->getTimezone() ?? new \DateTimeZone(\date_default_timezone_get()))->getName();
     }
 }

--- a/tests/Schedule/ScheduleRunContextTest.php
+++ b/tests/Schedule/ScheduleRunContextTest.php
@@ -23,6 +23,30 @@ use Zenstruck\ScheduleBundle\Tests\Fixture\MockTask;
  */
 final class ScheduleRunContextTest extends TestCase
 {
+    private string $timezone;
+
+    protected function setUp(): void
+    {
+        $this->timezone = \date_default_timezone_get();
+    }
+
+    protected function tearDown(): void
+    {
+        \date_default_timezone_set($this->timezone);
+    }
+
+    /**
+     * @test
+     */
+    public function start_time_timezone(): void
+    {
+        \date_default_timezone_set('America/New_York');
+
+        $context = new ScheduleRunContext(new Schedule());
+
+        $this->assertSame('America/New_York', $context->getStartTime()->getTimezone()->getName());
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
I had some timezone weirdness on PHP 8.1. My default system/php timezone is EST, I had not timezone configured in my tasks/schedule (it should use the default). All my daily/weekly/monthly tasks were running 5 hours _earlier_ than they should. I was able to fix the problem by explicitly setting the timezone in my schedule but I shouldn't have to do this.

I couldn't reproduce the exact issue but I believe it was caused by the calculation of the start time. It used `new \DateTime('@'.\time())` which sets the timezone to UTC. I guess the bundle was converting that to EST +5 hours.

This change uses `new \DateTime('now')` to calculate the start time which creates the object in the default system timezone.