### PR TITLE
fix bug in documentation

### DIFF
--- a/doc/define-schedule.md
+++ b/doc/define-schedule.md
@@ -73,7 +73,8 @@ and [schedule extensions](#schedule-extensions) can be configured:
 
 zenstruck_schedule:
     timezone: UTC
-    ping_on_success: https://example.com/schedule-success
+    schedule_extensions:
+        ping_on_success: https://example.com/schedule-success
 
     tasks:
         -   task: app:send-weekly-report --detailed


### PR DESCRIPTION
# before

```
 Unrecognized option "ping_on_success" under "zenstruck_schedule". Available options are "http_client", "mailer", "messenger", "
  notifier", "schedule_extensions", "single_server_lock_factory", "tasks", "timezone", "without_overlapping_lock_factory".
```

