### PR TITLE
Add support for custom task ids

### DIFF
--- a/src/Command/ScheduleListCommand.php
+++ b/src/Command/ScheduleListCommand.php
@@ -249,7 +249,14 @@ final class ScheduleListCommand extends Command
 
             $task = $taskGroup[0];
 
-            yield new \LogicException(\sprintf('Task "%s" (%s) is duplicated %d times. Make their descriptions unique to fix.', $task, $task->getExpression(), $count));
+            $description = \sprintf('Task "%s" (%s) is duplicated %d times. ', $task, $task->getExpression(), $count);
+            if ($task->hasCustomIdentifier()) {
+                $description .= 'Make sure to use unique identifiers.';
+            } else {
+                $description .= 'Make their descriptions unique to fix, or set a custom identifier with `identifiedBy`.';
+            }
+
+            yield new \LogicException($description);
         }
     }
 

--- a/src/Schedule/Task.php
+++ b/src/Schedule/Task.php
@@ -40,6 +40,7 @@ abstract class Task
 
     private string $expression = self::DEFAULT_EXPRESSION;
     private ?\DateTimeZone $timezone = null;
+    private ?string $customId = null;
 
     public function __construct(private string $description)
     {
@@ -47,6 +48,10 @@ abstract class Task
 
     final public function __toString(): string
     {
+        if ($this->customId) {
+            return "{$this->getType()} `$this->customId`: {$this->getDescription()}";
+        }
+
         return "{$this->getType()}: {$this->getDescription()}";
     }
 
@@ -57,7 +62,12 @@ abstract class Task
 
     final public function getId(): string
     {
-        return \sha1(static::class.$this->getExpression().$this->getDescription());
+        return $this->customId ?? \sha1(static::class.$this->getExpression().$this->getDescription());
+    }
+
+    final public function hasCustomIdentifier(): bool
+    {
+        return $this->customId !== null;
     }
 
     final public function getDescription(): string
@@ -91,6 +101,16 @@ abstract class Task
     final public function isDue(\DateTimeInterface $timestamp): bool
     {
         return $this->getExpression()->isDue($timestamp, $this->getTimezoneValue());
+    }
+
+    /**
+     * Set a unique identifier for this task.
+     */
+    final public function identifiedBy(string $id): self
+    {
+        $this->customId = $id;
+
+        return $this;
     }
 
     /**

--- a/tests/Command/ScheduleListCommandTest.php
+++ b/tests/Command/ScheduleListCommandTest.php
@@ -323,6 +323,8 @@ final class ScheduleListCommandTest extends TestCase
             ->addTask(new MockTask('task3'))
             ->addTask(new MockTask('task3'))
             ->addTask(new MockTask('task3'))
+            ->addTask((new MockTask('task4'))->identifiedBy('task4_id'))
+            ->addTask((new MockTask('task4'))->identifiedBy('task4_id'))
             ->getRunner()
         ;
 
@@ -335,9 +337,10 @@ final class ScheduleListCommandTest extends TestCase
         $output = $this->normalizeOutput($commandTester);
 
         $this->assertSame(1, $commandTester->getStatusCode());
-        $this->assertStringContainsString('[WARNING] 2 issues with schedule:', $output);
-        $this->assertStringContainsString('[ERROR] Task "MockTask: task2" (* * * * *) is duplicated 2 times. Make their descriptions unique to fix.', $output);
-        $this->assertStringContainsString('[ERROR] Task "MockTask: task3" (* * * * *) is duplicated 3 times. Make their descriptions unique to fix.', $output);
+        $this->assertStringContainsString('[WARNING] 3 issues with schedule:', $output);
+        $this->assertStringContainsString('[ERROR] Task "MockTask: task2" (* * * * *) is duplicated 2 times.', $output);
+        $this->assertStringContainsString('[ERROR] Task "MockTask: task3" (* * * * *) is duplicated 3 times.', $output);
+        $this->assertStringContainsString('[ERROR] Task "MockTask `task4_id`: task4" (* * * * *) is duplicated 2 times.', $output);
     }
 
     private function normalizeOutput(CommandTester $tester): string

--- a/tests/Schedule/TaskTest.php
+++ b/tests/Schedule/TaskTest.php
@@ -166,6 +166,12 @@ final class TaskTest extends TestCase
         })->getId(), self::task('task')->getId());
     }
 
+    public function uses_custom_id_when_set()
+    {
+        $this->assertSame('task', self::task()->identifiedBy('task1')->getId());
+        $this->assertNotSame(self::task()->identifiedBy('task1')->getId(), self::task()->getId());
+    }
+
     /**
      * @test
      *

--- a/tests/Schedule/TaskTest.php
+++ b/tests/Schedule/TaskTest.php
@@ -166,9 +166,12 @@ final class TaskTest extends TestCase
         })->getId(), self::task('task')->getId());
     }
 
+    /**
+     * @test
+     */
     public function uses_custom_id_when_set()
     {
-        $this->assertSame('task', self::task()->identifiedBy('task1')->getId());
+        $this->assertSame('task1', self::task()->identifiedBy('task1')->getId());
         $this->assertNotSame(self::task()->identifiedBy('task1')->getId(), self::task()->getId());
     }
 


### PR DESCRIPTION
Implementation for #78. I have not added additional checks for duplicated task ids, as I believe the relevant checks were already present in case for when the expression and description somehow matches.