### PR TITLE
Add task id to list command output

### DIFF
--- a/doc/cli-commands.md
+++ b/doc/cli-commands.md
@@ -18,7 +18,8 @@ Help:
 ```
 
 This command lists your currently defined schedule. It displays useful information
-and potential issues. The `--detail` option gives even more detail.
+and potential issues. The `--detail` option gives even more detail. Or add `--with-id`
+to add the task ids to the table output.
 
 It is advisable to run this command as a CI build step to ensure your schedule does
 not make it to production with issues (has exit code `1` if there are issues).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,7 +7,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:truncate\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: src/Command/ScheduleListCommand.php
 
 		-


### PR DESCRIPTION
I believe this addition to be convenient when looking for a specific task. The information is more compact compared to the `--detail` view and allows for easy id search, especially when combined with #81. It can be activated with the `--with-ids` option.

I've moved the description to a new line, and added a separator between each item. Result looks like this:

<img width="1437" alt="image" src="https://github.com/zenstruck/schedule-bundle/assets/1835343/5cb4daff-1f7a-44f3-b834-d9dada486132">

It was:

<img width="1554" alt="image" src="https://github.com/zenstruck/schedule-bundle/assets/1835343/1bbfd5b8-7933-44f2-893f-9b5f1f8f2aad">