### PR TITLE
Fix single server locking

### DIFF
--- a/src/Schedule/Extension/LockingExtension.php
+++ b/src/Schedule/Extension/LockingExtension.php
@@ -36,7 +36,7 @@ abstract class LockingExtension
             throw new \LogicException('A lock is already in place.');
         }
 
-        $this->lock = $lockFactory->createLock('symfony-schedule-'.$mutex, $this->ttl);
+        $this->lock = $lockFactory->createLock('symfony-schedule-'.$mutex, $this->ttl, false);
 
         if ($this->lock->acquire()) {
             return true;


### PR DESCRIPTION
The existing behaviour auto-released the lock once the `schedule:run`command finished execution.

For short running tasks (~1 second or less), auto-releasing the lock can lead to a case where if a cron starts slightly later on another server, the lock from the first invocation has already been deleted, and the task is executed for a second time. For a cluster of 3 app servers running in the same datacenter using Redis to store locks, I've noticed this happening fairly frequenty on ~1 second jobs (~30% of the time).

This change relies on the DEFAULT_TTL constant to tidy-up locks rather than doing so in this extension. I'm not entirely sure this is the best way of handling things, so I'm open to other ideas!